### PR TITLE
Bump AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         // see https://jcenter.bintray.com/com/android/tools/build/gradle/
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // markdown & unl-diagrams in javadoc
         // https://github.com/Abnaxos/pegdown-doclet

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 # see https://gradle.org/release-checksums/
 distributionSha256Sum=23e7d37e9bb4f8dabb8a3ea7fdee9dd0428b9b1a71d298aefd65b11dccea220f


### PR DESCRIPTION
```
Execution failed for task ':app:mergeReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > AAPT2 aapt2-4.1.3-6503028-linux Daemon #26: Unexpected error during compile '/home/vagrant/build/de.k3b.android.toGoZip/app/src/main/res/drawable-xxhdpi/ic_launcher.png', attempting to stop daemon.
     This should not happen under normal circumstances, please file an issue if it does.
```

https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

ref: https://gitlab.com/fdroid/fdroiddata/-/commit/5eeca9d87d9e4ab95d2fd61abaa4dc5127afd742